### PR TITLE
Fix error message showed when opening XLS file

### DIFF
--- a/src/Writer/XlsWriter.php
+++ b/src/Writer/XlsWriter.php
@@ -22,11 +22,6 @@ class XlsWriter implements TypedWriterInterface
     protected $filename;
 
     /**
-     * @var resource
-     */
-    protected $file;
-
-    /**
      * @var bool
      */
     protected $showHeaders;
@@ -34,8 +29,21 @@ class XlsWriter implements TypedWriterInterface
     /**
      * @var int
      */
-    protected $position;
+    protected $row;
 
+    /**
+     * @var int
+     */
+    protected $cell;
+    /**
+     * @var \PHPExcel
+     */
+    protected $objPHPExcel;
+
+    /**
+     * @var PHPExcel_Writer_IWriter
+     */
+    protected $objWriter;
     /**
      * @throws \RuntimeException
      *
@@ -46,7 +54,8 @@ class XlsWriter implements TypedWriterInterface
     {
         $this->filename = $filename;
         $this->showHeaders = $showHeaders;
-        $this->position = 0;
+        $this->row = 1;
+        $this->cell = 0;
 
         if (is_file($filename)) {
             throw new \RuntimeException(sprintf('The file %s already exist', $filename));
@@ -74,8 +83,10 @@ class XlsWriter implements TypedWriterInterface
      */
     public function open()
     {
-        $this->file = fopen($this->filename, 'w', false);
-        fwrite($this->file, '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><meta name=ProgId content=Excel.Sheet><meta name=Generator content="https://github.com/sonata-project/exporter"></head><body><table>');
+        $this->objPHPExcel = new \PHPExcel();
+
+        $this->objPHPExcel->setActiveSheetIndex(0);
+        $this->objWriter = \PHPExcel_IOFactory::createWriter($this->objPHPExcel, 'Excel5');
     }
 
     /**
@@ -83,8 +94,7 @@ class XlsWriter implements TypedWriterInterface
      */
     public function close()
     {
-        fwrite($this->file, '</table></body></html>');
-        fclose($this->file);
+        $this->objWriter->save('php://output');
     }
 
     /**
@@ -94,13 +104,12 @@ class XlsWriter implements TypedWriterInterface
     {
         $this->init($data);
 
-        fwrite($this->file, '<tr>');
         foreach ($data as $value) {
-            fwrite($this->file, sprintf('<td>%s</td>', $value));
+            $this->objPHPExcel->setActiveSheetIndex(0)->setCellValue($this->getNameFromNumber($this->cell) . $this->row, $value);
+            $this->cell++;
         }
-        fwrite($this->file, '</tr>');
-
-        ++$this->position;
+        $this->cell = 0;
+        $this->row++;
     }
 
     /**
@@ -110,17 +119,16 @@ class XlsWriter implements TypedWriterInterface
      */
     protected function init($data)
     {
-        if ($this->position > 0) {
-            return;
-        }
-
         if ($this->showHeaders) {
-            fwrite($this->file, '<tr>');
             foreach ($data as $header => $value) {
-                fwrite($this->file, sprintf('<th>%s</th>', $header));
+                $this->objPHPExcel->setActiveSheetIndex(0)->setCellValue($this->getNameFromNumber($this->cell) . "1", $header);
+                $this->objPHPExcel->getActiveSheet()->getStyle($this->getNameFromNumber($this->cell) . "1")->getFont()->setBold(true);
+                $this->objPHPExcel->getActiveSheet()->getColumnDimension($this->getNameFromNumber($this->cell))->setAutoSize(true);
+                $this->cell++;
             }
-            fwrite($this->file, '</tr>');
-            ++$this->position;
+            $this->showHeaders = false;
+            $this->row++;
         }
+        $this->cell = 0;
     }
 }


### PR DESCRIPTION
When downloading XLS file and opening it, a popup with message "File format and extension of 'filename.xls' don't match. The file could be corrupted or unsafe. Unless you trust its source, don't open it. Do you want to open it anyway?" showed. because the content file is HTML.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

In case of bug fix, `1.x` **MUST** be targeted.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Changing functions (XlsWriter::open(), XlsWriter:colse(), XlsWriter:write(data), XlsWriter:init(data)) and Using PHPExcel to generate an XLS file 

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
