### PR TITLE
[Add] Require PHPOffice/PHPExcel 1.8 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "symfony/http-kernel": "^2.3 || ^3.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "symfony/property-access": "^2.3 || ^3.0",
-        "symfony/routing": "^2.3 || ^3.0"
+        "symfony/routing": "^2.3 || ^3.0",
+        "phpoffice/phpexcel": "1.8"
     },
     "suggest": {
         "ext-curl": "*",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {adding a phpexcel requirment}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- adding require phpEXcel bundle

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [x] Update the documentation
- [ ] Add an upgrade note
